### PR TITLE
added android version argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ git clone https://github.com/nikgapps/config.git --depth=1
 - Build
 ```
 cd build
-python3 config_control.py <android ver>
+python3 config_control.py --androidVersion <android version>
 ```
 
 ## For Developers


### PR DESCRIPTION
added --androidVersion or -A argument under the self build section in the README otherwise fails with 
example : ```config_control.py: error: unrecognized arguments: <android version>```
while self building.