### PR TITLE
Allow debloating stuff that is already deleted over the air

### DIFF
--- a/NikGapps/Assets/addon
+++ b/NikGapps/Assets/addon
@@ -92,6 +92,27 @@ list_debloat_folders() {
   echo ""
 }
 
+list_force_debloat_folders() {
+  echo ""
+  echo "force_debloat_folders() {"
+  echo "cat <<EOF"
+
+  if [ -f "$debloaterSource" ]; then
+    OLD_IFS="$IFS"
+    IFS="$(printf '%b_' ' \n')"
+    IFS="${IFS%_}"
+    g=$(grep "forceDebloat" "$debloaterSource" | cut -d= -f2)
+    for i in $g; do
+      echo "$i"
+    done
+    IFS="$OLD_IFS"
+  fi
+
+  echo "EOF"
+  echo "}"
+  echo ""
+}
+
 backup() {
   echo " backup)"
   echo "   ui_print \"- Backing up $fileName\""
@@ -111,6 +132,7 @@ restore() {
   echo "   done"
   echo "   delete_aosp_apps"
   echo "   debloat_apps"
+  echo "   force_debloat_apps"
   echo "   for i in \$(list_files); do"
   echo "     f=\$(get_output_path \"\$S/\$i\")"
   echo "     chown root:root \"\$f\""
@@ -168,6 +190,7 @@ cat "$COMMONDIR/header" >> "$dest"
   list_files
   list_delete_folders
   list_debloat_folders
+  list_force_debloat_folders
   run
 } >>"$dest"
 chmod 755 "$dest"

--- a/NikGapps/Assets/functions.sh
+++ b/NikGapps/Assets/functions.sh
@@ -65,6 +65,29 @@ debloat_apps(){
   done
 }
 
+force_debloat_apps(){
+  for i in $(force_debloat_folders); do
+    addToLog "- Force Debloating $i"
+    if [ "${i#*/*}" != "$i" ]; then
+      for j in "/postinstall$S/$i" "/postinstall/$i" "$S/$i" "/$i"; do
+        addToLog "- Checking if $j exists"
+        if [ -f "$j" ] || [ -d "$j" ]; then
+          addToLog "- Found, deleting $j"
+          rm -rf "$j"
+        fi
+      done
+    else
+      for j in $(find "/system" "/product" "/system_ext" -iname "$i"); do
+        addToLog "- Checking if $j exists"
+        if [ -f "$j" ] || [ -d "$j" ]; then
+          addToLog "- Found, deleting $j"
+          rm -rf "$j"
+        fi
+      done
+    fi
+  done
+}
+
 find_config() {
   nikgapps_config_file_name="$nikGappsDir/nikgapps.config"
   for location in "/tmp" "/sdcard1" "/sdcard1/NikGapps" "/sdcard" "/storage/emulated/NikGapps" "/storage/emulated"; do

--- a/NikGapps/Assets/nikgapps_functions.sh
+++ b/NikGapps/Assets/nikgapps_functions.sh
@@ -274,7 +274,13 @@ copy_logs() {
   copy_file "$COMMONDIR/size_after.txt" "$logDir/partitions/size_after.txt"
   copy_file "$COMMONDIR/size_after_readable.txt" "$logDir/partitions/size_after_readable.txt"
   copy_file_logs "after"
-  for f in $PROPFILES; do
+  for f in $(find /system -iname "*.prop" 2>/dev/null); do
+    copy_file "$f" "$logDir/propfiles/$f"
+  done
+  for f in $(find /product -iname "*.prop" 2>/dev/null); do
+    copy_file "$f" "$logDir/propfiles/$f"
+  done
+  for f in $(find /system_ext -iname "*.prop" 2>/dev/null); do
     copy_file "$f" "$logDir/propfiles/$f"
   done
   for f in $addon_scripts_logDir; do
@@ -368,15 +374,17 @@ debloat() {
             IFS="$OLD_IFS"
           else
             addToLog "- No $i folders to debloat"
+            update_prop "$i" "forceDebloat" "$propFilePath" "$debloaterFilesPath"
           fi
         else
-          rmv "$i"
-          update_prop "$i" "debloat" "$propFilePath" "$debloaterFilesPath"
+          addToLog "- Force Removing $i"
+          rm -rf "$i"
+          update_prop "$i" "forceDebloat" "$propFilePath" "$debloaterFilesPath"
         fi
       fi
     done
     if [ $debloaterRan = 1 ]; then
-      update_prop "$propFilePath" "install" "$debloaterFilesPath"
+      update_prop "$propFilePath" "install" "$propFilePath" "$debloaterFilesPath"
       . $COMMONDIR/addon "Debloater" "$propFilePath" "$addon_index"
       copy_file "$system/addon.d/$addon_index-Debloater.sh" "$logDir/addonscripts/$addon_index-Debloater.sh"
     fi
@@ -1182,11 +1190,6 @@ RemoveAospAppsFromRom() {
       addToLog "- No $1 folders to remove" "$3"
     fi
   fi
-}
-
-rmv() {
-  addToLog "- Removing $1"
-  rm -rf "$1"
 }
 
 set_perm() {


### PR DESCRIPTION
- Up until now, when we configured debloater.config to delete something, the addon.d qualified the Folders only if they existed in the system.
- Now, we're introducing the ability to debloat stuff at runtime (with OTA update) so ensure the entries made in debloater.config are re-evaluated during the restore phase of OTA update and force debloat apps.